### PR TITLE
Handle optional contour data when drawing debug bubbles

### DIFF
--- a/core/pipeline.py
+++ b/core/pipeline.py
@@ -91,8 +91,8 @@ def process_region(
         return [], []
     
     debug = img.copy()
-    for _, (x1,y1,x2,y2) in bubble_crops:
-        cv2.rectangle(debug, (x1,y1),(x2,y2),(0,0,255),2)
+    for _, (x1, y1, x2, y2), *_ in bubble_crops:
+        cv2.rectangle(debug, (x1, y1), (x2, y2), (0, 0, 255), 2)
     cv2.imwrite("debug_bubbles.png", debug)
 
     t2 = time.perf_counter()


### PR DESCRIPTION
## Summary
- avoid unpacking error when bubble detection includes contour data

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pre-commit run --files core/pipeline.py` *(fails: CalledProcessError: git fetch origin --tags, 403)*

------
https://chatgpt.com/codex/tasks/task_e_688e1b9a2ccc832c8ce1c9a41f91d2cf