### PR TITLE
[OCR] Filter out tiny bubbles

### DIFF
--- a/app.py
+++ b/app.py
@@ -123,6 +123,8 @@ class TranslatorApp:
         self.conf_threshold = float(cfg.get("ocr_confidence_threshold", 0.5))
         self.highlight_color = cfg.get("highlight_color", "#ffff00")
         self.highlight_width = int(cfg.get("highlight_width", 2))
+        self.min_bubble_width = int(cfg.get("bubble_min_width", 25))
+        self.min_bubble_height = int(cfg.get("bubble_min_height", 25))
 
         self.root = build_root_window()
         self.canvas = build_overlay_canvas(self.root, self.region)
@@ -266,6 +268,8 @@ class TranslatorApp:
             timings,
             save_bubble_images=self.save_bubble_images,
             conf_threshold=self.conf_threshold,
+            min_width=self.min_bubble_width,
+            min_height=self.min_bubble_height,
         )
 
         self.current_blocks = blocks

--- a/config.json
+++ b/config.json
@@ -28,6 +28,8 @@
   "ocr_confidence_threshold": 0.5,
   "subtitle_mode": false,
   "highlight_color": "#ffff00",
-  "highlight_width": 2
+  "highlight_width": 2,
+  "bubble_min_width": 25,
+  "bubble_min_height": 25
 }
 

--- a/core/config.py
+++ b/core/config.py
@@ -23,6 +23,8 @@ DEFAULT_CONFIG: Dict[str, Any] = {
         "history": "f6",
     },
     "bubble_padding": 8,
+    "bubble_min_width": 25,
+    "bubble_min_height": 25,
     "replace_mode": False,
     "save_bubble_images": False,
     "overflow_to_nearby": False,

--- a/core/pipeline.py
+++ b/core/pipeline.py
@@ -69,6 +69,8 @@ def process_region(
     timings: dict[str, float] | None = None,
     save_bubble_images: bool = False,
     conf_threshold: float = 0.5,
+    min_width: int = 25,
+    min_height: int = 25,
 ) -> Tuple[List[Tuple[str, Tuple[int, int, int, int], float, int, Any]], List[str]]:
     """Run detection, OCR and translation for a region.
 
@@ -79,6 +81,8 @@ def process_region(
         timings: Optional dict to store timing information.
         save_bubble_images: If ``True``, cropped bubbles are stored to disk.
         conf_threshold: Warn when estimated OCR confidence is below this value.
+        min_width: Minimum bubble width in pixels.
+        min_height: Minimum bubble height in pixels.
 
     Returns:
         tuple[list, list[str]]: OCR blocks and corresponding translations.
@@ -94,7 +98,13 @@ def process_region(
     if timings is not None:
         timings["grab_region"] = t1 - t0
 
-    bubble_crops = detect_bubbles(img, padding=bubble_padding, return_contours=True)
+    bubble_crops = detect_bubbles(
+        img,
+        padding=bubble_padding,
+        min_width=min_width,
+        min_height=min_height,
+        return_contours=True,
+    )
     logging.info("Detected %d bubbles", len(bubble_crops))
     if not bubble_crops:
         logging.info("No bubbles detected. Skipping OCR.")

--- a/core/yolo_bubble.py
+++ b/core/yolo_bubble.py
@@ -18,13 +18,19 @@ DEBUG_IMAGES = os.environ.get("DEBUG_IMAGES") == "1"
 
 
 def detect_bubbles(
-    image: np.ndarray, padding: int = 0, return_contours: bool = False
+    image: np.ndarray,
+    padding: int = 0,
+    min_width: int = 25,
+    min_height: int = 25,
+    return_contours: bool = False,
 ) -> List[Tuple]:
     """Detect speech bubbles and optionally pad the boxes.
 
     Args:
         image: Source image in BGR order.
         padding: Extra pixels around detected boxes.
+        min_width: Minimum bubble width in pixels.
+        min_height: Minimum bubble height in pixels.
         return_contours: If ``True``, also return the bubble contour points.
 
     Returns:
@@ -38,6 +44,9 @@ def detect_bubbles(
         height, width = image.shape[:2]
         for box in results.boxes.xyxy:
             x1, y1, x2, y2 = map(int, box)
+            w, h = x2 - x1, y2 - y1
+            if w < min_width or h < min_height:
+                continue
             if padding:
                 x1 = max(0, x1 - padding)
                 y1 = max(0, y1 - padding)


### PR DESCRIPTION
## Summary
- allow configuring minimum bubble width and height
- skip YOLO detections below the configured size
- plumb min-size filtering through pipeline and app configuration

## Testing
- `black app.py core/config.py core/yolo_bubble.py core/pipeline.py`
- `flake8 app.py core/config.py core/yolo_bubble.py core/pipeline.py`
- `pytest --maxfail=1 --disable-warnings -q`

------
https://chatgpt.com/codex/tasks/task_e_688e6405b214832c9e3d5c81e2febe64